### PR TITLE
Add Streamlit financial casting app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Casting
-Casting
+
+This app provides a small example of using the OpenAI Agents SDK with
+Streamlit to analyse financial statements. Upload a file such as a CSV or
+Excel spreadsheet and the app can compute simple *casting* totals (summing all
+numeric columns). You can also query an OpenAI model about the contents of the
+file.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and set your `OPENAI_API_KEY`.
+2. Install the required dependencies (for example with `pip install -r requirements.txt`).
+3. Run the app with `streamlit run streamlit_app.py`.
+

--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from types import SimpleNamespace
+import os
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - fallback when openai isn't available
+    OpenAI = None
+
+@dataclass
+class Agent:
+    name: str
+    instructions: str
+    model: str = "gpt-4o"
+
+class Runner:
+    """Simple wrapper to execute an agent synchronously."""
+
+    @staticmethod
+    def run_sync(agent: Agent, input: str):
+        if OpenAI is None:
+            return SimpleNamespace(final_output="OpenAI library not installed.")
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        response = client.chat.completions.create(
+            model=agent.model,
+            messages=[
+                {"role": "system", "content": agent.instructions},
+                {"role": "user", "content": input},
+            ],
+        )
+        return SimpleNamespace(final_output=response.choices[0].message.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+streamlit
+pandas
+PyPDF2
+docx
+python-dotenv
+openai

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,7 +2,10 @@ import os
 import streamlit as st
 import pandas as pd
 from dotenv import load_dotenv
-from openai import OpenAI
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - fallback when openai isn't available
+    OpenAI = None
 from PyPDF2 import PdfReader
 from docx import Document
 from agents import Agent, Runner
@@ -10,7 +13,10 @@ from agents import Agent, Runner
 # Load API key from .env
 load_dotenv()
 openai_api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=openai_api_key)
+if OpenAI:
+    client = OpenAI(api_key=openai_api_key)
+else:
+    client = None
 
 st.title("Agentic File Assistant (using Agents SDK)")
 
@@ -36,22 +42,41 @@ def extract_text(f):
         content = df.to_csv(index=False)
     return content
 
+def load_dataframe(f):
+    """Return a DataFrame if file is csv or excel."""
+    df = None
+    if f.type == "text/csv":
+        f.seek(0)
+        df = pd.read_csv(f)
+    elif f.type.endswith("sheet"):
+        f.seek(0)
+        df = pd.read_excel(f)
+    return df
+
+def cast_financials(df: pd.DataFrame) -> pd.Series:
+    """Simple casting: sum numeric columns."""
+    if df is None:
+        return pd.Series()
+    numeric_df = df.select_dtypes(include="number")
+    return numeric_df.sum()
+
 if uploaded:
     text = extract_text(uploaded)
+    df = load_dataframe(uploaded)
     if not text:
         st.warning("Could not extract text.")
     else:
         st.text_area("Preview", text[:2000], height=300)
+        if df is not None and st.button("Compute Casting"):
+            totals = cast_financials(df)
+            st.subheader("Casting Totals")
+            st.write(totals)
+
         user_query = st.text_input("Ask your agent about this file:")
 
         if st.button("Run Agent") and user_query:
-            agent = Agent(
-                name="File Agent",
-                instructions=(
-                    "Extract the document in markdown"
-                ),
-                model="gpt-4o"
-            )
+            instructions = "Analyze the financial statement and provide findings in markdown."
+            agent = Agent(name="File Agent", instructions=instructions, model="gpt-4o")
             prompt = f"{text[:4000]}\n\nUser question: {user_query}"
             result = Runner.run_sync(agent, input=prompt)
             st.markdown("**Agent Response:**")


### PR DESCRIPTION
## Summary
- implement a simple `Agent` wrapper around the OpenAI client
- extend `streamlit_app.py` to calculate casting totals for numeric data and query an agent
- document how to run the app
- add Python requirements

## Testing
- `python3 -m py_compile agents.py streamlit_app.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_b_68871b9e141c83339c23f437bcdbbb4b