### PR TITLE
Add Streamlit multi-agent pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,7 @@ cover everything provided in the upload.
 
 When you press **Analyze Financials** in the web interface, the app runs four
 agents in sequence: it extracts the statements, extracts the notes, compares
-the figures and then produces a summary table of any issues found.
+the figures and then produces a summary table of any issues found. As each step
+runs the page shows which agent is executing and only the final summary table
+is displayed.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Casting
-Casting
+
+This app provides a small example of using the OpenAI Agents SDK with
+Streamlit to analyse financial statements. Upload a file such as a CSV or
+Excel spreadsheet and the app can compute simple *casting* totals (summing all
+numeric columns). It also demonstrates a pipeline of multiple agents that
+extract statements and notes, compare the numbers and output a summary table
+of any discrepancies.
+
+The entire file text is passed to the agents so the casting and analysis
+cover everything provided in the upload.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and set your `OPENAI_API_KEY`.
+2. Install the required dependencies (for example with `pip install -r requirements.txt`).
+3. Run the app with `streamlit run streamlit_app.py`.
+
+When you press **Analyze Financials** in the web interface, the app runs four
+agents in sequence: it extracts the statements, extracts the notes, compares
+the figures and then produces a summary table of any issues found.
+

--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from types import SimpleNamespace
+import os
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - fallback when openai isn't available
+    OpenAI = None
+
+@dataclass
+class Agent:
+    name: str
+    instructions: str
+    model: str = "gpt-4o"
+
+class Runner:
+    """Simple wrapper to execute an agent synchronously."""
+
+    @staticmethod
+    def run_sync(agent: Agent, input: str):
+        if OpenAI is None or not os.getenv("OPENAI_API_KEY"):
+            return SimpleNamespace(final_output="OpenAI API not configured.")
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        response = client.chat.completions.create(
+            model=agent.model,
+            messages=[
+                {"role": "system", "content": agent.instructions},
+                {"role": "user", "content": input},
+            ],
+        )
+        return SimpleNamespace(final_output=response.choices[0].message.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+streamlit
+pandas
+PyPDF2
+python-docx
+python-dotenv
+openai

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,4 +1,3 @@
-import os
 import streamlit as st
 import pandas as pd
 from dotenv import load_dotenv
@@ -12,7 +11,6 @@ from agents import Agent, Runner
 
 # Load API key from .env
 load_dotenv()
-openai_api_key = os.getenv("OPENAI_API_KEY")
 
 st.title("Agentic File Assistant (using Agents SDK)")
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,7 +2,10 @@ import os
 import streamlit as st
 import pandas as pd
 from dotenv import load_dotenv
-from openai import OpenAI
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - fallback when openai isn't available
+    OpenAI = None
 from PyPDF2 import PdfReader
 from docx import Document
 from agents import Agent, Runner
@@ -10,7 +13,6 @@ from agents import Agent, Runner
 # Load API key from .env
 load_dotenv()
 openai_api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=openai_api_key)
 
 st.title("Agentic File Assistant (using Agents SDK)")
 
@@ -36,23 +38,72 @@ def extract_text(f):
         content = df.to_csv(index=False)
     return content
 
+def load_dataframe(f):
+    """Return a DataFrame if file is csv or excel."""
+    df = None
+    if f.type == "text/csv":
+        f.seek(0)
+        df = pd.read_csv(f)
+    elif f.type.endswith("sheet"):
+        f.seek(0)
+        df = pd.read_excel(f)
+    return df
+
+def cast_financials(df: pd.DataFrame) -> pd.Series:
+    """Simple casting: sum numeric columns."""
+    if df is None:
+        return pd.Series()
+    numeric_df = df.select_dtypes(include="number")
+    return numeric_df.sum()
+
 if uploaded:
     text = extract_text(uploaded)
+    df = load_dataframe(uploaded)
     if not text:
         st.warning("Could not extract text.")
     else:
-        st.text_area("Preview", text[:2000], height=300)
-        user_query = st.text_input("Ask your agent about this file:")
+        st.info("File uploaded successfully.")
+        if df is not None and st.button("Compute Casting"):
+            totals = cast_financials(df)
+            st.subheader("Casting Totals")
+            st.write(totals)
 
-        if st.button("Run Agent") and user_query:
-            agent = Agent(
-                name="File Agent",
+        if st.button("Analyze Financials"):
+            fin_agent = Agent(
+                name="Financial Extractor",
                 instructions=(
-                    "Extract the document in markdown"
+                    "Extract the profit & loss statement, statement of financial "
+                    "position, statement of changes in equity and cashflow "
+                    "statement for both years. Respond in Markdown."
                 ),
-                model="gpt-4o"
             )
-            prompt = f"{text[:4000]}\n\nUser question: {user_query}"
-            result = Runner.run_sync(agent, input=prompt)
-            st.markdown("**Agent Response:**")
-            st.write(result.final_output)
+            notes_agent = Agent(
+                name="Notes Extractor",
+                instructions="Extract the notes for both years. Respond in Markdown.",
+            )
+            compare_agent = Agent(
+                name="Comparison Agent",
+                instructions=(
+                    "Compare the figures in the financial statements and the "
+                    "notes and identify any discrepancies. Respond in Markdown."
+                ),
+            )
+            summary_agent = Agent(
+                name="Summary Agent",
+                instructions=(
+                    "Summarize the discrepancies in a concise Markdown table "
+                    "with columns 'Item' and 'Issue'."
+                ),
+            )
+
+            with st.spinner("Running Financial Extractor..."):
+                fin_result = Runner.run_sync(fin_agent, input=text)
+            with st.spinner("Running Notes Extractor..."):
+                notes_result = Runner.run_sync(notes_agent, input=text)
+            compare_input = f"STATEMENTS:\n{fin_result.final_output}\n\nNOTES:\n{notes_result.final_output}"
+            with st.spinner("Running Comparison Agent..."):
+                compare_result = Runner.run_sync(compare_agent, input=compare_input)
+            with st.spinner("Running Summary Agent..."):
+                summary_result = Runner.run_sync(summary_agent, input=compare_result.final_output)
+            st.markdown("**Summary of Errors:**")
+            st.write(summary_result.final_output)


### PR DESCRIPTION
## Summary
- extend `Runner.run_sync` to handle missing API configuration
- add four-agent pipeline to analyze financial statements in Streamlit
- document the new pipeline in the README
- disable file preview in the Streamlit app
- process the entire file instead of truncating input

## Testing
- `python3 -m py_compile agents.py streamlit_app.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_b_68871b9e141c83339c23f437bcdbbb4b